### PR TITLE
Fix locale not being passed to translated_field

### DIFF
--- a/lib/ecto_translate.ex
+++ b/lib/ecto_translate.ex
@@ -88,7 +88,7 @@ defmodule EctoTranslate do
         This will cause a query to be run to get the translation.
         """
         def unquote(:"translated_#{(field)}")(%{__meta__: %{source: {_,translatable_type}}, id: translatable_id} = model, locale \\ nil) do
-          locale = Atom.to_string(locale || String.to_atom(Translate.current_locale))
+          locale = Atom.to_string(locale || String.to_atom(EctoTranslate.current_locale))
           record = EctoTranslate
           |> where(translatable_type: ^translatable_type, locale: ^locale, translatable_id: ^translatable_id, field: unquote(Atom.to_string(field)))
           |> unquote(repo).one

--- a/lib/ecto_translate.ex
+++ b/lib/ecto_translate.ex
@@ -88,9 +88,9 @@ defmodule EctoTranslate do
         This will cause a query to be run to get the translation.
         """
         def unquote(:"translated_#{(field)}")(%{__meta__: %{source: {_,translatable_type}}, id: translatable_id} = model, locale \\ nil) do
-          locale = locale || EctoTranslate.current_locale
+          locale = Atom.to_string(locale || String.to_atom(Translate.current_locale))
           record = EctoTranslate
-          |> where(translatable_type: ^translatable_type, translatable_id: ^translatable_id, field: unquote(Atom.to_string(field)))
+          |> where(translatable_type: ^translatable_type, locale: ^locale, translatable_id: ^translatable_id, field: unquote(Atom.to_string(field)))
           |> unquote(repo).one
 
           case record do
@@ -120,6 +120,7 @@ defmodule EctoTranslate do
 
         Map.merge(model, translations)
       end
+      def translate!([], _), do: []
       def translate!(models, locale) when is_list(models) do
         locale = Atom.to_string((locale || String.to_atom(EctoTranslate.current_locale)))
         ids = Enum.map(models, fn model -> model.id end)


### PR DESCRIPTION
Previously the locale was not used and the query crashed with  the following error when you had more than 1 translation for a field:

```
(Ecto.MultipleResultsError) expected at most one result but got 2 in query:

from t in EctoTranslate,
  where: t.translatable_type == ^"points_of_interest" and t.translatable_id == ^52 and t.field == "title"
```

I have also added a fallback to `translate!` when the collection was empty. In that case the following line crashed:
```
%{__meta__: %{source: {_,translatable_type}}} = Enum.at(models, 0)
```