### PR TITLE
Add info for `import Ecto.Query` before `use EctoTranslate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Docs can be found [here](https://smeevil.github.io/ecto_translate/EctoTranslate.
     ```elixir
     defmodule MyApp.Post do
       ...
+      import Ecto.Query
       use EctoTranslate, [:title, :body]
       ...
       schema "posts" do
@@ -137,6 +138,7 @@ Docs can be found [here](https://smeevil.github.io/ecto_translate/EctoTranslate.
       ...
     end
     ```
+    **Important:** Don't forget to import `Ecto.Query` before `use EctoTranslate`
 
 1. Set translations for your data
 


### PR DESCRIPTION
Hi,

When i started to use this library one problem got me.

Since `phx.gen` does not import `Ecto.Query` the `use EctoTranslate, [:col]` caused compile errors.

It took me a while to figure out the problem and i thought it may be a good idea to add a hint on readme about this problem.

Cheers