### PR TITLE
Add id custom type and migration generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Docs can be found [here](https://smeevil.github.io/ecto_translate/EctoTranslate.
 
     ```elixir
     def deps do
-      [{:ecto_translate, "~> 0.1.0"}]
+      [{:ecto_translate, "~> 0.2.3"}]
     end
     ```
 
@@ -80,38 +80,24 @@ Docs can be found [here](https://smeevil.github.io/ecto_translate/EctoTranslate.
     end
     ```
 
-1. Create a migration for the translation table :
+1. Configure translatable_id_type if neccessary.
+
+    If your models does not use integer primary keys, (e.g: they use binary id)
+    you can configure EctoTranslate to use a different type of column type on
+    translatable_id.
+
+    To do this simply config `:ecto_translate` otp app for `:translatable_id_type`
+    with your choice of type. (e.g: binary_id, string, etc.)
+
+      ```elixir
+      config :ecto_translate,
+          translatable_id_type: :binary_id
+      ```
+
+1. Create a migration for the translation table by running:
 
     ```shell
-    mix ecto.gen.migration create_translations
-    vi priv/repo/migrations/<date>_create_translations.exs
-    ```
-
-    ```elixir
-    defmodule MyApp.Repo.Migrations.CreateTranslations do
-      use Ecto.Migration
-
-      def change do
-        create table(:test_model) do
-          add :title, :string
-          add :description, :string
-        end
-
-
-        create table(:translations) do
-          add :translatable_id, :integer
-          add :translatable_type, :string
-          add :locale, :string
-          add :field, :string
-          add :content, :text
-
-          timestamps
-        end
-        create index :translations, [:translatable_id, :translatable_type]
-        create index :translations, [:translatable_id, :translatable_type, :locale]
-        create unique_index(:translations, [:translatable_id, :translatable_type, :locale, :field])
-      end
-    end
+    mix ecto_translate.gen.migration
     ```
 
 1. Migrate
@@ -128,6 +114,7 @@ Docs can be found [here](https://smeevil.github.io/ecto_translate/EctoTranslate.
     ```elixir
     defmodule MyApp.Post do
       ...
+      import Ecto.Query
       use EctoTranslate, [:title, :body]
       ...
       schema "posts" do
@@ -137,6 +124,7 @@ Docs can be found [here](https://smeevil.github.io/ecto_translate/EctoTranslate.
       ...
     end
     ```
+    **Important:** Don't forget to import `Ecto.Query` before `use EctoTranslate`
 
 1. Set translations for your data
 

--- a/lib/ecto_translate.ex
+++ b/lib/ecto_translate.ex
@@ -46,7 +46,6 @@ defmodule EctoTranslate do
   """
   use Ecto.Schema
 
-  import Ecto
   import Ecto.Changeset
   import Ecto.Query
 
@@ -145,13 +144,32 @@ defmodule EctoTranslate do
     {translatable_fields_ast, {translated_field_ast, translate_ast}}
   end
 
+  @translatable_id_type Application.get_env(:ecto_translate, :translatable_id_type, :integer)
+
+  @doc """
+  Returns translatable id type configured for application
+
+  The id type can be configured by setting `:translatable_id_type` config for
+  `:ecto_translate` otp application.
+
+  ## Example
+  ```elixir
+    config ecto_translate,
+      translatable_id_type: :string
+  ```
+
+  By default the is type is presumed as `:integer`
+  """
+  @spec translatable_id_type :: atom()
+  def translatable_id_type, do: @translatable_id_type
+
   schema "translations" do
-    field :translatable_id, :integer
+    field :translatable_id, @translatable_id_type
     field :translatable_type, :string
     field :locale, :string
     field :field, :string
     field :content, :string
-    timestamps
+    timestamps()
   end
 
   @repo Application.get_env(:ecto_translate, :repo)

--- a/lib/mix/tasks/gen_migration.ex
+++ b/lib/mix/tasks/gen_migration.ex
@@ -1,0 +1,96 @@
+defmodule Mix.Tasks.EctoTranslate.Gen.Migration do
+  @moduledoc """
+  Generates a migration for translation table
+
+  This task is able to take same arguments as `ecto.gen.migration` except name
+
+  ## Exmaples
+
+      mix ecto_translate.gen.migration
+      mix ecto_translate.gen.migration -r Custom.Repo
+
+  The generated migration filename will be prefixed with the current
+  timestamp in UTC which is used for versioning and ordering.
+
+  By default, the migration will be generated to the
+    "priv/YOUR_REPO/migrations" directory of the current application
+    but it can be configured to be any subdirectory of `priv` by
+    specifying the `:priv` key under the repository configuration.
+
+    This generator will automatically open the generated file if
+    you have `ECTO_EDITOR` set in your environment variable.
+
+    ## Command line options
+
+      * `-r`, `--repo` - the repo to generate migration for
+  """
+  use Mix.Task
+
+  import Macro, only: [camelize: 1, underscore: 1]
+  import Mix.Generator
+  import Mix.Ecto
+
+  @migration_name "ecto_translate_table"
+
+  @shortdoc "Generates a new migration for the EctoTranslate translation table"
+
+  def run(args) do
+    no_umbrella!("ecto_translate.gen.migration")
+    repos = parse_repo(args)
+
+    Enum.each repos, fn repo ->
+      ensure_repo(repo, args)
+      path = migrations_path(repo)
+      file = Path.join(path, "#{timestamp()}_#{underscore(@migration_name)}.exs")
+      create_directory path
+
+      assigns = [mod: Module.concat([repo, Migrations, camelize(@migration_name)]),
+                 change: change()]
+      create_file file, migration_template(assigns)
+
+      if open?(file) and Mix.shell.yes?("Do you want to run this migration?") do
+        Mix.Task.run "ecto.migrate", [repo]
+      end
+    end
+  end
+
+  defp timestamp do
+    {{y, m, d}, {hh, mm, ss}} = :calendar.universal_time()
+    "#{y}#{pad(m)}#{pad(d)}#{pad(hh)}#{pad(mm)}#{pad(ss)}"
+  end
+
+  defp pad(i) when i < 10, do: << ?0, ?0 + i >>
+  defp pad(i), do: to_string(i)
+
+  defp change do
+    """
+        create table(:test_model) do
+          add :title, :string
+          add :description, :string
+        end
+
+        create table(:translations) do
+          add :translatable_id, #{inspect(EctoTranslate.translatable_id_type())}
+          add :translatable_type, :string
+          add :locale, :string
+          add :field, :string
+          add :content, :text
+
+          timestamps
+        end
+
+        create index :translations, [:translatable_id, :translatable_type]
+        create index :translations, [:translatable_id, :translatable_type, :locale]
+        create unique_index(:translations, [:translatable_id, :translatable_type, :locale, :field])
+    """
+  end
+
+  embed_template :migration, """
+  defmodule <%= inspect @mod %> do
+    use Ecto.Migration
+    def change do
+  <%= @change %>
+    end
+  end
+  """
+end


### PR DESCRIPTION
This PR adds ability to change `translatable_id`s type on Ecto migrations and schema

### Notes:

 - There is no API changed whatsoever so a patch bump will be ok in case of merging.
 - The README is updated with new instructions on migration generator.
 - The README is updated with instructions about changing `translatable_id`s type.

Cheers