### PR TITLE
Remove test_model from migration generator

### DIFF
--- a/lib/mix/tasks/gen_migration.ex
+++ b/lib/mix/tasks/gen_migration.ex
@@ -70,11 +70,6 @@ defmodule Mix.Tasks.EctoTranslate.Gen.Migration do
 
   defp change do
     """
-        create table(:test_model) do
-          add :title, :string
-          add :description, :string
-        end
-
         create table(:translations) do
           add :translatable_id, #{inspect(EctoTranslate.translatable_id_type())}
           add :translatable_type, :string


### PR DESCRIPTION
A test_model database was left in the migration generator template by my mistake. (sorry :cry:)