### PR TITLE
Add support for ecto 3.1.x and 3.2.x

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,6 @@ defmodule EctoTranslate.Mixfile do
           :race_conditions
         ]
       ]
-
     ]
   end
 
@@ -51,11 +50,11 @@ defmodule EctoTranslate.Mixfile do
       {:credo, ">= 0.0.0", only: [:dev, :test]},
       {:dialyxir, "~> 1.0.0-rc.3", only: [:dev], runtime: false},
       {:earmark, ">= 0.0.0", only: :dev},
-      {:ecto, "~>3.0.7"},
-      {:ecto_sql, ">=3.0.5"},
+      {:ecto, ">= 3.0.0 and < 3.3.0"},
+      {:ecto_sql, ">= 3.0.5"},
       {:ex_doc, ">= 0.0.0", only: :dev},
       {:excoveralls, ">= 0.0.0 ", only: :test},
-      {:gettext, "~>0.16.1"},
+      {:gettext, "~> 0.16.1"},
       {:postgrex, ">= 0.14.1", only: [:dev, :test]}
     ]
   end


### PR DESCRIPTION
Fix #13 

This version will support `ecto` package versions:

 - `3.0[.x]`
 - `3.1[.x]`
 - `3.2[.x]`